### PR TITLE
Rename event

### DIFF
--- a/src/translate/de.ts
+++ b/src/translate/de.ts
@@ -29,7 +29,7 @@ const de = {
     },
     newEvent: {
       datum: '17\nSEP',
-      header: 'Talk-Abend',
+      header: 'Community-Abend',
       place: 'Chinesisches Restaurant (Falkensee-Garten) um 18 Uhr',
       address: 'Max-Liebermann-Straße 33, 14612 Falkensee',
       contain: 'Komm vorbei (und bring vielleicht einen Freund mit)',

--- a/src/translate/en.ts
+++ b/src/translate/en.ts
@@ -29,7 +29,7 @@ const en = {
     },
     newEvent: {
       datum: 'SEP\n17',
-      header: 'Talk evening',
+      header: 'Community Evening',
       place: 'Chinese restaurant (Falkensee-Garten) at 6pm',
       address: 'Max-Liebermann-Straße 33, 14612 Falkensee',
       contain: 'Bring yourself (and maybe a friend).',


### PR DESCRIPTION
Talk-Abend might sound like there are talks given by people -- so let's call it "community evening" instead ☺️ 