### PR TITLE
Fix Next Event card: markdown, timezone, Kids Labs routing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Fetch Meetup events
+        env:
+          TZ: Europe/Berlin
         run: npx tsx scripts/fetch-meetup-events.ts
       - name: Build
         run: npm run build

--- a/scripts/fetch-meetup-events.ts
+++ b/scripts/fetch-meetup-events.ts
@@ -26,13 +26,37 @@ function formatLocalISO(date: Date): string {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
 }
 
+const MAX_DESCRIPTION_LENGTH = 180;
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/\\([-_*`[\](){}#+!])/g, '$1')
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/(\*\*|__)(.*?)\1/g, '$2')
+    .replace(/(\*|_)(.*?)\1/g, '$2')
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+    .replace(/^\s*[-*+]\s+/gm, '')
+    .replace(/^\s*>+\s?/gm, '')
+    .replace(/^\s*(?:-{3,}|\*{3,}|_{3,})\s*$/gm, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  const cut = text.slice(0, max);
+  const lastSpace = cut.lastIndexOf(' ');
+  return (lastSpace > max * 0.6 ? cut.slice(0, lastSpace) : cut).trimEnd() + '…';
+}
+
 function cleanDescription(desc: string): string {
-  // iCal descriptions often start with the group name on the first line - strip it
   const lines = desc.split('\n');
-  if (lines.length > 1 && lines[0].includes('Havelland Technology')) {
-    return lines.slice(1).join('\n').trim();
-  }
-  return desc.trim();
+  const body = lines.length > 1 && lines[0].includes('Havelland Technology')
+    ? lines.slice(1).join('\n')
+    : desc;
+  return truncate(stripMarkdown(body), MAX_DESCRIPTION_LENGTH);
 }
 
 async function fetchEvents(): Promise<void> {

--- a/src/component/event.tsx
+++ b/src/component/event.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
 import Program from "./program";
 import BorderedBox from "./borderedBox";
 import meetupData from "../data/meetup-events.json";
@@ -10,6 +11,7 @@ type CardProps = {
     address: string;
     contain: string;
     link?: string;
+    internalLink?: string;
     isLast?: boolean;
     showProgram?: boolean;
 };
@@ -56,13 +58,16 @@ function useEventCards(events: MeetupEvent[]): CardProps[] {
 
         const place = venueName ? `${venueName} ${timeStr}` : timeStr;
 
+        const isKidsLabs = /kids\s*labs/i.test(event.title);
+
         return {
             datum,
             header: event.title,
             place,
             address,
             contain: event.description,
-            link: event.eventUrl || undefined,
+            link: isKidsLabs ? undefined : (event.eventUrl || undefined),
+            internalLink: isKidsLabs ? '/labs' : undefined,
         };
     });
 }
@@ -80,13 +85,14 @@ function formatTime(date: Date, lang: string): string {
     return minutes === 0 ? `${h12}${period}` : `${h12}:${String(minutes).padStart(2, '0')}${period}`;
 }
 
-const Card = ({ datum, header, place, address, contain, link, showProgram }: CardProps) => {
+const Card = ({ datum, header, place, address, contain, link, internalLink, showProgram }: CardProps) => {
     const isCafe = header.toLowerCase().includes('programmiercaf');
+    const hasLink = Boolean(link || internalLink);
     const cardContent = (
         <div className="border-4 border-black shadow-[4px_4px_0px_#000] p-2 md:p-4 w-full flex flex-col items-center justify-center">
             <div
                 key={`contentCard-${datum}`}
-                className={` w-full flex md:flex-row flex-col items-center justify-between md:gap-6 gap-3 max-w-[1120px] bg-white ${link ? 'hover:shadow-[6px_6px_0px_#000] cursor-pointer hover:bg-green-50' : ''}`}>
+                className={` w-full flex md:flex-row flex-col items-center justify-between md:gap-6 gap-3 max-w-[1120px] bg-white ${hasLink ? 'hover:shadow-[6px_6px_0px_#000] cursor-pointer hover:bg-green-50' : ''}`}>
                 <BorderedBox>
                     <div
                         className={`
@@ -110,6 +116,14 @@ const Card = ({ datum, header, place, address, contain, link, showProgram }: Car
         </div>
     );
 
+    if (internalLink) {
+        return (
+            <Link to={internalLink} className="w-full flex justify-center no-underline text-inherit">
+                {cardContent}
+            </Link>
+        );
+    }
+
     if (link) {
         return (
             <a href={link} target="_blank" rel="noopener noreferrer" className="w-full flex justify-center no-underline text-inherit">
@@ -122,12 +136,13 @@ const Card = ({ datum, header, place, address, contain, link, showProgram }: Car
 }
 
 const Event = () => {
+    const { t } = useTranslation();
     const cardData = useEventCards(meetupData.upcomingEvents);
 
     return (
         <div
             className="bg-white gap-2.5 w-full px-2 md:px-8 py-4 md:py-8 flex flex-col items-center justify-around max-w-[1120px] mx-auto">
-            <h2 className="font-['Press_Start_2P'] font-normal text-base text-[#00274a]">Next Event</h2>
+            <h2 className="font-['Press_Start_2P'] font-normal text-base text-[#00274a]">{t('event.nextEvent')}</h2>
             {cardData.map((event: CardProps, index: number) => (
                 <Card key={index} {...event} />
             ))}

--- a/src/component/translateBtn.tsx
+++ b/src/component/translateBtn.tsx
@@ -42,6 +42,7 @@ export default function TranslateBtn() {
                     key={lng}
                     onClick={() => handleLanguageChange(lng)}
                     disabled={i18n.resolvedLanguage === lng}
+                    aria-label={`Switch language to ${lngs[lng].nativeName}`}
                 >
                     {lngs[lng].svg}
                 </button>

--- a/src/translate/de.ts
+++ b/src/translate/de.ts
@@ -84,9 +84,10 @@ const de = {
       at: 'um',
       oclock: 'Uhr',
       fromTo: 'von {{from}} bis {{to}}',
+      nextEvent: 'Nächstes Event',
     },
       gallery: {
-        highline: 'Gallery'},
+        highline: 'Galerie'},
       kids: {
         // Hero
         title: 'KIDS LABS',

--- a/src/translate/en.ts
+++ b/src/translate/en.ts
@@ -85,6 +85,7 @@ const en = {
       at: 'at',
       oclock: '',
       fromTo: 'from {{from}} to {{to}}',
+      nextEvent: 'Next Event',
     },
       gallery:
           {highline: 'Gallery'},


### PR DESCRIPTION
## Summary
- Strip+truncate Meetup markdown in `cleanDescription()` so the Next Event card stops rendering raw `**bold**`, `[text](url)` and `\---` separators (root cause: iCal description was dumped as plain text).
- Fix event times showing 2h earlier than reality (`from 8am to 11am` for a 10-13 Berlin event). Workflow now sets `TZ=Europe/Berlin` so `formatLocalISO()` writes Berlin-local instead of UTC-local.
- Kids Labs events now open `/labs` (react-router `Link`) instead of the Meetup event page.
- Replace hardcoded `"Next Event"` with `t('event.nextEvent')`; fill in DE; also fix `gallery.highline` DE (`Gallery` → `Galerie`).
- Minor a11y: `aria-label` on the language switcher buttons.

## Test plan
- [ ] Dev server: `/` renders the Next Event card with clean, truncated text (no `**`, no `[...](...)`)
- [ ] Click a Kids Labs card → navigates to `/labs` client-side (no full reload, no meetup.com)
- [ ] Click a non–Kids Labs card (e.g. Programmiercafé) → still opens the Meetup URL in a new tab
- [ ] Switch to DE → heading says "Nächstes Event", gallery heading says "Galerie"
- [ ] After next CI run: `src/data/meetup-events.json` `dateTime` matches Berlin-local time

🤖 Generated with [Claude Code](https://claude.com/claude-code)