### PR TITLE
Sync package-lock.json to fix CI deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -287,9 +287,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {


### PR DESCRIPTION
## Summary
- Regenerated `package-lock.json` — `@emnapi/wasi-threads` bumped 1.2.0 → 1.2.1 and `@emnapi/core`/`@emnapi/runtime` 1.9.2 were missing, causing `npm ci` to fail in the deploy workflow.

## Test plan
- [x] `npm install` — lockfile back in sync
- [x] `npm run build` — passes
- [ ] GitHub Actions `npm ci` step succeeds on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)