### PR TITLE
Add Call for Speakers page and component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Footer from "./component/footer";
 import HomePage from "./pages/HomePage";
 import KidsPage from "./pages/KidsPage";
 import DatenschutzPage from "./pages/DatenschutzPage";
+import SpeakersPage from "./pages/SpeakersPage";
 
 
 function App() {
@@ -21,6 +22,7 @@ function App() {
                     <Route path="/" element={<HomePage />} />
                     <Route path="/labs" element={<KidsPage />} />
                     <Route path="/labs/datenschutz" element={<DatenschutzPage />} />
+                    <Route path="/speakers" element={<SpeakersPage />} />
                 </Routes>
             </main>
             <Footer/>

--- a/src/component/callForSpeakers.tsx
+++ b/src/component/callForSpeakers.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-import MailOutlineIcon from "@mui/icons-material/MailOutline";
 import { buildMailto } from "../utils/buildMailto";
+import MailtoCtaButton from "./ui/mailtoCtaButton";
 
 function CallForSpeakers() {
     const { t } = useTranslation();
@@ -21,12 +21,7 @@ function CallForSpeakers() {
                 {t('callForSpeakers.teaser')}
             </p>
             <div className="flex flex-wrap gap-4 justify-center items-center mt-2">
-                <a
-                    href={mailto}
-                    className="inline-flex font-['Press_Start_2P'] text-xs md:text-sm bg-[#27945c] text-white border-4 border-[#0d1b21] px-6 py-3 shadow-[4px_4px_0_#0d1b21] transition-all duration-100 ease-in-out hover:transform hover:-translate-x-1 hover:-translate-y-1 no-underline items-center gap-2"
-                >
-                    <MailOutlineIcon fontSize="small" /> {t('callForSpeakers.buttonSubmit')}
-                </a>
+                <MailtoCtaButton href={mailto} label={t('callForSpeakers.buttonSubmit')} />
                 <Link
                     to="/speakers"
                     className="inline-flex font-['Press_Start_2P'] text-xs md:text-sm bg-[#fefefe] text-[#00274a] border-4 border-[#00274a] px-6 py-3 shadow-[4px_4px_0_#0d1b21] transition-all duration-100 ease-in-out hover:transform hover:-translate-x-1 hover:-translate-y-1 no-underline items-center"

--- a/src/component/callForSpeakers.tsx
+++ b/src/component/callForSpeakers.tsx
@@ -1,0 +1,41 @@
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import MailOutlineIcon from "@mui/icons-material/MailOutline";
+import { buildMailto } from "../utils/buildMailto";
+
+function CallForSpeakers() {
+    const { t } = useTranslation();
+
+    const mailto = buildMailto({
+        to: 'meetup@hvltech.de',
+        subject: t('callForSpeakers.mailtoSubject'),
+        body: t('callForSpeakers.mailtoBody'),
+    });
+
+    return (
+        <div className="bg-white gap-4 text-center w-full px-8 py-8 flex flex-col items-center justify-around max-w-[1120px] mx-auto">
+            <h2 className="font-['Press_Start_2P'] font-normal text-base text-[#00274a]">
+                {t('callForSpeakers.headline')}
+            </h2>
+            <p className="max-w-2xl leading-relaxed text-[#0d1b21]">
+                {t('callForSpeakers.teaser')}
+            </p>
+            <div className="flex flex-wrap gap-4 justify-center items-center mt-2">
+                <a
+                    href={mailto}
+                    className="inline-flex font-['Press_Start_2P'] text-xs md:text-sm bg-[#27945c] text-white border-4 border-[#0d1b21] px-6 py-3 shadow-[4px_4px_0_#0d1b21] transition-all duration-100 ease-in-out hover:transform hover:-translate-x-1 hover:-translate-y-1 no-underline items-center gap-2"
+                >
+                    <MailOutlineIcon fontSize="small" /> {t('callForSpeakers.buttonSubmit')}
+                </a>
+                <Link
+                    to="/speakers"
+                    className="inline-flex font-['Press_Start_2P'] text-xs md:text-sm bg-[#fefefe] text-[#00274a] border-4 border-[#00274a] px-6 py-3 shadow-[4px_4px_0_#0d1b21] transition-all duration-100 ease-in-out hover:transform hover:-translate-x-1 hover:-translate-y-1 no-underline items-center"
+                >
+                    {t('callForSpeakers.buttonLearnMore')} →
+                </Link>
+            </div>
+        </div>
+    );
+}
+
+export default CallForSpeakers;

--- a/src/component/footer.tsx
+++ b/src/component/footer.tsx
@@ -22,7 +22,6 @@ export default function Footer() {
                 </Link>
                 <Link
                     to="/speakers"
-                    onClick={() => window.scrollTo(0, 0)}
                     className="text-white text-xs font-['Press_Start_2P'] hover:text-green-400 transition-colors no-underline flex items-center gap-1"
                 >
                     {t('footerSpeakers')}

--- a/src/component/footer.tsx
+++ b/src/component/footer.tsx
@@ -1,9 +1,11 @@
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import text from '../assets/text.svg';
 import logo from '../assets/logo/logo_no_text.svg';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 
 export default function Footer() {
+    const { t } = useTranslation();
     return (
         <footer className="h-12 w-full bg-[#00274a]">
             <div className='flex justify-center items-center gap-6 h-full w-full'>
@@ -17,6 +19,13 @@ export default function Footer() {
                     className="text-white text-xs font-['Press_Start_2P'] hover:text-green-400 transition-colors no-underline flex items-center gap-1"
                 >
                     <img src={logo} alt="" className="h-4 brightness-0 invert" /> Kids Labs
+                </Link>
+                <Link
+                    to="/speakers"
+                    onClick={() => window.scrollTo(0, 0)}
+                    className="text-white text-xs font-['Press_Start_2P'] hover:text-green-400 transition-colors no-underline flex items-center gap-1"
+                >
+                    {t('footerSpeakers')}
                 </Link>
             </div>
         </footer>

--- a/src/component/ui/mailtoCtaButton.tsx
+++ b/src/component/ui/mailtoCtaButton.tsx
@@ -1,0 +1,17 @@
+import MailOutlineIcon from "@mui/icons-material/MailOutline";
+
+type MailtoCtaButtonProps = {
+    href: string;
+    label: string;
+};
+
+export default function MailtoCtaButton({ href, label }: MailtoCtaButtonProps) {
+    return (
+        <a
+            href={href}
+            className="inline-flex font-['Press_Start_2P'] text-xs md:text-sm bg-[#27945c] text-white border-4 border-[#0d1b21] px-6 py-3 shadow-[4px_4px_0_#0d1b21] transition-all duration-100 ease-in-out hover:transform hover:-translate-x-1 hover:-translate-y-1 no-underline items-center gap-2"
+        >
+            <MailOutlineIcon fontSize="small" /> {label}
+        </a>
+    );
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -6,6 +6,7 @@ import Event from "../component/event";
 import Gallery from "../component/gallery";
 import Countdown from "../component/countdown";
 import AnimatedPixelBackground from "../component/AnimatedPixelBackground";
+import CallForSpeakers from "../component/callForSpeakers";
 import { useSeo } from "../utils/useSeo";
 
 
@@ -70,6 +71,10 @@ function HomePage() {
                         <ListItem>{t('whyTakePart.benefits5')}</ListItem>
                     </ul>
                 </div>
+            </section>
+
+            <section id="callForSpeakers">
+                <CallForSpeakers/>
             </section>
 
             <section>

--- a/src/pages/SpeakersPage.tsx
+++ b/src/pages/SpeakersPage.tsx
@@ -1,13 +1,13 @@
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-import MailOutlineIcon from "@mui/icons-material/MailOutline";
 import logo from "../assets/logo/logo_no_text.svg";
 import BorderedBox from "../component/borderedBox";
+import MailtoCtaButton from "../component/ui/mailtoCtaButton";
 import { useSeo } from "../utils/useSeo";
 import { buildMailto } from "../utils/buildMailto";
 
-type Format = { key: string; icon: string; label: string; description: string };
+type Format = { icon: string; label: string; description: string };
 
 function SpeakersPage() {
     const { t } = useTranslation();
@@ -31,10 +31,10 @@ function SpeakersPage() {
         body: t('callForSpeakers.mailtoBody'),
     });
 
-    const ctaClass = "inline-flex font-['Press_Start_2P'] text-xs md:text-sm bg-[#27945c] text-white border-4 border-[#0d1b21] px-6 py-3 shadow-[4px_4px_0_#0d1b21] transition-all duration-100 ease-in-out hover:transform hover:-translate-x-1 hover:-translate-y-1 no-underline items-center gap-2";
+    const submitLabel = t('callForSpeakers.buttonSubmit');
 
     return (
-        <div className="bg-white min-h-screen">
+        <>
             <Link
                 to="/"
                 className="fixed top-[34px] left-4 sm:left-8 md:left-12 lg:left-16 xl:left-1/2 xl:-translate-x-[560px] z-[60] bg-black/30 backdrop-blur-sm text-white hover:bg-black/50 px-3 py-1.5 rounded-full text-xs font-semibold no-underline flex items-center gap-1.5 transition-colors"
@@ -42,7 +42,6 @@ function SpeakersPage() {
                 ← <img src={logo} alt="" className="h-3.5 brightness-0 invert" /> HVLtech
             </Link>
 
-            {/* Hero */}
             <section className="bg-[#00274a] text-white">
                 <div className="max-w-[1120px] mx-auto px-8 py-20 text-center">
                     <h1 className="font-['Press_Start_2P'] text-xl md:text-2xl lg:text-3xl leading-relaxed mb-6 [text-shadow:_2px_2px_0_#0d1b21,_4px_4px_0_#0d1b21]">
@@ -51,14 +50,11 @@ function SpeakersPage() {
                     <p className="text-base md:text-lg max-w-2xl mx-auto leading-relaxed mb-8 text-white/90">
                         {t('callForSpeakers.intro')}
                     </p>
-                    <a href={mailto} className={ctaClass}>
-                        <MailOutlineIcon fontSize="small" /> {t('callForSpeakers.buttonSubmit')}
-                    </a>
+                    <MailtoCtaButton href={mailto} label={submitLabel} />
                 </div>
             </section>
 
-            {/* Audience */}
-            <section>
+            <section className="bg-white">
                 <div className="max-w-[1120px] mx-auto px-8 py-12 text-center">
                     <h2 className="font-['Press_Start_2P'] font-normal text-base text-[#00274a] mb-4">
                         {t('callForSpeakers.audienceTitle')}
@@ -69,7 +65,6 @@ function SpeakersPage() {
                 </div>
             </section>
 
-            {/* Formats */}
             <section className="bg-[#fefefe]">
                 <div className="max-w-[1120px] mx-auto px-8 py-12">
                     <h2 className="font-['Press_Start_2P'] font-normal text-base text-[#00274a] mb-8 text-center">
@@ -77,7 +72,7 @@ function SpeakersPage() {
                     </h2>
                     <div className="grid md:grid-cols-3 gap-2">
                         {formats.map((format) => (
-                            <BorderedBox key={format.key} className="bg-white p-6 flex flex-col">
+                            <BorderedBox key={format.label} className="bg-white p-6 flex flex-col">
                                 <div className="text-3xl mb-3" aria-hidden="true">{format.icon}</div>
                                 <h3 className="font-['Press_Start_2P'] text-xs text-[#00274a] mb-3 leading-relaxed">
                                     {format.label}
@@ -91,15 +86,14 @@ function SpeakersPage() {
                 </div>
             </section>
 
-            {/* What we offer */}
-            <section>
+            <section className="bg-white">
                 <div className="max-w-[1120px] mx-auto px-8 py-12">
                     <h2 className="font-['Press_Start_2P'] font-normal text-base text-[#00274a] mb-6 text-center">
                         {t('callForSpeakers.offerTitle')}
                     </h2>
-                    <ul className="list-none pl-8 max-w-2xl mx-auto [-webkit-text-indent:-0.8em] text-indent-[-0.8em]">
-                        {offer.map((item, i) => (
-                            <li key={i} className="pb-1.5 before:content-['■'] before:text-[#008000] before:inline-block before:w-[1.3em] before:ml-[-0.5em]">
+                    <ul className="list-none pl-8 max-w-2xl mx-auto [text-indent:-0.8em]">
+                        {offer.map((item) => (
+                            <li key={item} className="pb-1.5 before:content-['■'] before:text-[#008000] before:inline-block before:w-[1.3em] before:ml-[-0.5em]">
                                 {item}
                             </li>
                         ))}
@@ -107,7 +101,6 @@ function SpeakersPage() {
                 </div>
             </section>
 
-            {/* What to include in your email */}
             <section className="bg-[#fefefe]">
                 <div className="max-w-[1120px] mx-auto px-8 py-12">
                     <h2 className="font-['Press_Start_2P'] font-normal text-base text-[#00274a] mb-6 text-center">
@@ -115,8 +108,8 @@ function SpeakersPage() {
                     </h2>
                     <BorderedBox className="bg-white p-6 max-w-2xl mx-auto">
                         <ol className="list-decimal pl-6 space-y-2 text-[#0d1b21]">
-                            {emailContents.map((item, i) => (
-                                <li key={i} className="leading-relaxed">{item}</li>
+                            {emailContents.map((item) => (
+                                <li key={item} className="leading-relaxed">{item}</li>
                             ))}
                         </ol>
                     </BorderedBox>
@@ -126,12 +119,9 @@ function SpeakersPage() {
                 </div>
             </section>
 
-            {/* Final CTA */}
-            <section>
+            <section className="bg-white">
                 <div className="max-w-[1120px] mx-auto px-8 py-16 text-center">
-                    <a href={mailto} className={ctaClass}>
-                        <MailOutlineIcon fontSize="small" /> {t('callForSpeakers.buttonSubmit')}
-                    </a>
+                    <MailtoCtaButton href={mailto} label={submitLabel} />
                     <div className="mt-8">
                         <Link
                             to="/"
@@ -142,7 +132,7 @@ function SpeakersPage() {
                     </div>
                 </div>
             </section>
-        </div>
+        </>
     );
 }
 

--- a/src/pages/SpeakersPage.tsx
+++ b/src/pages/SpeakersPage.tsx
@@ -1,0 +1,149 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import MailOutlineIcon from "@mui/icons-material/MailOutline";
+import logo from "../assets/logo/logo_no_text.svg";
+import BorderedBox from "../component/borderedBox";
+import { useSeo } from "../utils/useSeo";
+import { buildMailto } from "../utils/buildMailto";
+
+type Format = { key: string; icon: string; label: string; description: string };
+
+function SpeakersPage() {
+    const { t } = useTranslation();
+    useSeo({
+        title: 'Call for Speakers — HVLtech: Share a talk in Falkensee',
+        description: 'Submit a talk for the HVLtech meetup in Falkensee. Lightning, standard or workshop, in German or English — first-time speakers welcome.',
+        path: '/speakers',
+    });
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, []);
+
+    const formats = t('callForSpeakers.formats', { returnObjects: true }) as Format[];
+    const offer = t('callForSpeakers.offer', { returnObjects: true }) as string[];
+    const emailContents = t('callForSpeakers.emailContents', { returnObjects: true }) as string[];
+
+    const mailto = buildMailto({
+        to: 'meetup@hvltech.de',
+        subject: t('callForSpeakers.mailtoSubject'),
+        body: t('callForSpeakers.mailtoBody'),
+    });
+
+    const ctaClass = "inline-flex font-['Press_Start_2P'] text-xs md:text-sm bg-[#27945c] text-white border-4 border-[#0d1b21] px-6 py-3 shadow-[4px_4px_0_#0d1b21] transition-all duration-100 ease-in-out hover:transform hover:-translate-x-1 hover:-translate-y-1 no-underline items-center gap-2";
+
+    return (
+        <div className="bg-white min-h-screen">
+            <Link
+                to="/"
+                className="fixed top-[34px] left-4 sm:left-8 md:left-12 lg:left-16 xl:left-1/2 xl:-translate-x-[560px] z-[60] bg-black/30 backdrop-blur-sm text-white hover:bg-black/50 px-3 py-1.5 rounded-full text-xs font-semibold no-underline flex items-center gap-1.5 transition-colors"
+            >
+                ← <img src={logo} alt="" className="h-3.5 brightness-0 invert" /> HVLtech
+            </Link>
+
+            {/* Hero */}
+            <section className="bg-[#00274a] text-white">
+                <div className="max-w-[1120px] mx-auto px-8 py-20 text-center">
+                    <h1 className="font-['Press_Start_2P'] text-xl md:text-2xl lg:text-3xl leading-relaxed mb-6 [text-shadow:_2px_2px_0_#0d1b21,_4px_4px_0_#0d1b21]">
+                        {t('callForSpeakers.headline')}
+                    </h1>
+                    <p className="text-base md:text-lg max-w-2xl mx-auto leading-relaxed mb-8 text-white/90">
+                        {t('callForSpeakers.intro')}
+                    </p>
+                    <a href={mailto} className={ctaClass}>
+                        <MailOutlineIcon fontSize="small" /> {t('callForSpeakers.buttonSubmit')}
+                    </a>
+                </div>
+            </section>
+
+            {/* Audience */}
+            <section>
+                <div className="max-w-[1120px] mx-auto px-8 py-12 text-center">
+                    <h2 className="font-['Press_Start_2P'] font-normal text-base text-[#00274a] mb-4">
+                        {t('callForSpeakers.audienceTitle')}
+                    </h2>
+                    <p className="max-w-2xl mx-auto leading-relaxed text-[#0d1b21]">
+                        {t('callForSpeakers.audience')}
+                    </p>
+                </div>
+            </section>
+
+            {/* Formats */}
+            <section className="bg-[#fefefe]">
+                <div className="max-w-[1120px] mx-auto px-8 py-12">
+                    <h2 className="font-['Press_Start_2P'] font-normal text-base text-[#00274a] mb-8 text-center">
+                        {t('callForSpeakers.formatsTitle')}
+                    </h2>
+                    <div className="grid md:grid-cols-3 gap-2">
+                        {formats.map((format) => (
+                            <BorderedBox key={format.key} className="bg-white p-6 flex flex-col">
+                                <div className="text-3xl mb-3" aria-hidden="true">{format.icon}</div>
+                                <h3 className="font-['Press_Start_2P'] text-xs text-[#00274a] mb-3 leading-relaxed">
+                                    {format.label}
+                                </h3>
+                                <p className="text-sm text-[#0d1b21] leading-relaxed">
+                                    {format.description}
+                                </p>
+                            </BorderedBox>
+                        ))}
+                    </div>
+                </div>
+            </section>
+
+            {/* What we offer */}
+            <section>
+                <div className="max-w-[1120px] mx-auto px-8 py-12">
+                    <h2 className="font-['Press_Start_2P'] font-normal text-base text-[#00274a] mb-6 text-center">
+                        {t('callForSpeakers.offerTitle')}
+                    </h2>
+                    <ul className="list-none pl-8 max-w-2xl mx-auto [-webkit-text-indent:-0.8em] text-indent-[-0.8em]">
+                        {offer.map((item, i) => (
+                            <li key={i} className="pb-1.5 before:content-['■'] before:text-[#008000] before:inline-block before:w-[1.3em] before:ml-[-0.5em]">
+                                {item}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </section>
+
+            {/* What to include in your email */}
+            <section className="bg-[#fefefe]">
+                <div className="max-w-[1120px] mx-auto px-8 py-12">
+                    <h2 className="font-['Press_Start_2P'] font-normal text-base text-[#00274a] mb-6 text-center">
+                        {t('callForSpeakers.emailContentsTitle')}
+                    </h2>
+                    <BorderedBox className="bg-white p-6 max-w-2xl mx-auto">
+                        <ol className="list-decimal pl-6 space-y-2 text-[#0d1b21]">
+                            {emailContents.map((item, i) => (
+                                <li key={i} className="leading-relaxed">{item}</li>
+                            ))}
+                        </ol>
+                    </BorderedBox>
+                    <p className="text-center text-sm italic text-[#0d1b21] mt-6 max-w-2xl mx-auto">
+                        {t('callForSpeakers.selection')}
+                    </p>
+                </div>
+            </section>
+
+            {/* Final CTA */}
+            <section>
+                <div className="max-w-[1120px] mx-auto px-8 py-16 text-center">
+                    <a href={mailto} className={ctaClass}>
+                        <MailOutlineIcon fontSize="small" /> {t('callForSpeakers.buttonSubmit')}
+                    </a>
+                    <div className="mt-8">
+                        <Link
+                            to="/"
+                            className="inline-block font-['Press_Start_2P'] text-xs bg-[#fefefe] text-[#00274a] border-4 border-[#00274a] px-4 py-2 shadow-[4px_4px_0_#0d1b21] transition-all duration-100 ease-in-out hover:transform hover:-translate-x-1 hover:-translate-y-1 no-underline"
+                        >
+                            ← {t('callForSpeakers.backToMain')}
+                        </Link>
+                    </div>
+                </div>
+            </section>
+        </div>
+    );
+}
+
+export default SpeakersPage;

--- a/src/translate/de.ts
+++ b/src/translate/de.ts
@@ -96,9 +96,9 @@ const de = {
         audience: 'Etwa 20–50 Teilnehmer*innen aus Falkensee und dem Havelland — Hobbyist*innen und Profis, gemischte Erfahrungslevel, freundliche Atmosphäre. Vorträge sind auf Deutsch, Englisch oder wie du magst.',
         formatsTitle: 'Wähle ein Format',
         formats: [
-          { key: 'lightning', icon: '⚡', label: 'Lightning · 5–10 Min.', description: 'Eine kurze Demo, eine pointierte Meinung, ein Tool, das du liebst. Perfekt für den ersten Vortrag.' },
-          { key: 'standard',  icon: '🎤', label: 'Standard · 20–25 Min. + Q&A', description: 'Ein tieferer Einblick in ein Thema deiner Wahl, gefolgt von einer offenen Diskussion.' },
-          { key: 'workshop',  icon: '🛠️', label: 'Workshop · 45–60 Min.', description: 'Eine praktische Session, bei der das Publikum mitbaut oder mitlernt.' }
+          { icon: '⚡', label: 'Lightning · 5–10 Min.', description: 'Eine kurze Demo, eine pointierte Meinung, ein Tool, das du liebst. Perfekt für den ersten Vortrag.' },
+          { icon: '🎤', label: 'Standard · 20–25 Min. + Q&A', description: 'Ein tieferer Einblick in ein Thema deiner Wahl, gefolgt von einer offenen Diskussion.' },
+          { icon: '🛠️', label: 'Workshop · 45–60 Min.', description: 'Eine praktische Session, bei der das Publikum mitbaut oder mitlernt.' }
         ],
         offerTitle: 'Was wir Vortragenden bieten',
         offer: [

--- a/src/translate/de.ts
+++ b/src/translate/de.ts
@@ -88,6 +88,53 @@ const de = {
     },
       gallery: {
         highline: 'Galerie'},
+      callForSpeakers: {
+        headline: 'Du hast etwas zu erzählen? Wir hören gern zu.',
+        intro: 'Egal ob fertiger Vortrag oder halbgare Idee – wir freuen uns, von dir zu hören. Keine Vortragserfahrung nötig — wir helfen dir bei der Vorbereitung.',
+        teaser: 'Du hast etwas Cooles gebaut, etwas auf die harte Tour gelernt oder eine starke Meinung zu einem Tech-Thema? Teile es mit unserer Community in Falkensee.',
+        audienceTitle: 'Vor wem du sprichst',
+        audience: 'Etwa 20–50 Teilnehmer*innen aus Falkensee und dem Havelland — Hobbyist*innen und Profis, gemischte Erfahrungslevel, freundliche Atmosphäre. Vorträge sind auf Deutsch, Englisch oder wie du magst.',
+        formatsTitle: 'Wähle ein Format',
+        formats: [
+          { key: 'lightning', icon: '⚡', label: 'Lightning · 5–10 Min.', description: 'Eine kurze Demo, eine pointierte Meinung, ein Tool, das du liebst. Perfekt für den ersten Vortrag.' },
+          { key: 'standard',  icon: '🎤', label: 'Standard · 20–25 Min. + Q&A', description: 'Ein tieferer Einblick in ein Thema deiner Wahl, gefolgt von einer offenen Diskussion.' },
+          { key: 'workshop',  icon: '🛠️', label: 'Workshop · 45–60 Min.', description: 'Eine praktische Session, bei der das Publikum mitbaut oder mitlernt.' }
+        ],
+        offerTitle: 'Was wir Vortragenden bieten',
+        offer: [
+          'Ein freundliches Publikum und hausgemachten Kuchen',
+          'Auf Wunsch eine Generalprobe mit einem Organisator',
+          'Folien-Review und Themen-Brainstorming, wenn du magst',
+          'Such dir die Sprache aus: Deutsch, Englisch oder egal',
+          'Optionale Aufzeichnung — nur wenn du zustimmst'
+        ],
+        emailContentsTitle: 'Was sollte in deine E-Mail',
+        emailContents: [
+          'Dein Name',
+          'Titel des Vortrags',
+          'Kurze Beschreibung (2–4 Sätze)',
+          'Gewünschtes Format (Lightning / Standard / Workshop)',
+          'Sprache (DE / EN / egal)',
+          'Kurzvita (optional, ein Satz)'
+        ],
+        selection: 'Wir nehmen laufend Einreichungen an — Antwort kommt meist innerhalb von etwa zwei Wochen.',
+        buttonSubmit: 'Talk einreichen',
+        buttonLearnMore: 'Mehr erfahren',
+        backToMain: 'Zurück zur Hauptseite',
+        mailtoSubject: 'Talk-Vorschlag für HVLtech',
+        mailtoBody:
+          'Hallo HVLtech-Team,\n\n' +
+          'ich möchte einen Vortrag einreichen:\n\n' +
+          'Name:\n' +
+          'Titel des Vortrags:\n' +
+          'Kurze Beschreibung (2–4 Sätze):\n' +
+          '\n' +
+          'Gewünschtes Format (Lightning / Standard / Workshop):\n' +
+          'Sprache (DE / EN / egal):\n' +
+          'Kurzvita (optional, ein Satz):\n\n' +
+          'Danke!\n'
+      },
+      footerSpeakers: 'Vortragende',
       kids: {
         // Hero
         title: 'KIDS LABS',

--- a/src/translate/en.ts
+++ b/src/translate/en.ts
@@ -97,9 +97,9 @@ const en = {
         audience: 'Around 20–50 attendees from Falkensee and the Havelland — hobbyists and professionals, mixed levels, friendly atmosphere. Talks can be in German, English, or whichever you prefer.',
         formatsTitle: 'Pick a format',
         formats: [
-          { key: 'lightning', icon: '⚡', label: 'Lightning · 5–10 min', description: 'A quick demo, a hot take, a tool you love. Perfect for first-time speakers.' },
-          { key: 'standard',  icon: '🎤', label: 'Standard · 20–25 min + Q&A', description: 'A deeper dive into a topic of your choice, followed by an open discussion.' },
-          { key: 'workshop',  icon: '🛠️', label: 'Workshop · 45–60 min', description: 'A hands-on session where the audience builds or learns alongside you.' }
+          { icon: '⚡', label: 'Lightning · 5–10 min', description: 'A quick demo, a hot take, a tool you love. Perfect for first-time speakers.' },
+          { icon: '🎤', label: 'Standard · 20–25 min + Q&A', description: 'A deeper dive into a topic of your choice, followed by an open discussion.' },
+          { icon: '🛠️', label: 'Workshop · 45–60 min', description: 'A hands-on session where the audience builds or learns alongside you.' }
         ],
         offerTitle: 'What we offer speakers',
         offer: [

--- a/src/translate/en.ts
+++ b/src/translate/en.ts
@@ -89,6 +89,53 @@ const en = {
     },
       gallery:
           {highline: 'Gallery'},
+      callForSpeakers: {
+        headline: 'Got something to share? We want to hear it.',
+        intro: 'Whether you have a polished talk or a half-baked idea, we would love to hear from you. No experience required — we will help you prepare.',
+        teaser: 'Built something cool, learned something the hard way, or have a strong opinion about a tech topic? Share it with our community in Falkensee.',
+        audienceTitle: 'Who you will be talking to',
+        audience: 'Around 20–50 attendees from Falkensee and the Havelland — hobbyists and professionals, mixed levels, friendly atmosphere. Talks can be in German, English, or whichever you prefer.',
+        formatsTitle: 'Pick a format',
+        formats: [
+          { key: 'lightning', icon: '⚡', label: 'Lightning · 5–10 min', description: 'A quick demo, a hot take, a tool you love. Perfect for first-time speakers.' },
+          { key: 'standard',  icon: '🎤', label: 'Standard · 20–25 min + Q&A', description: 'A deeper dive into a topic of your choice, followed by an open discussion.' },
+          { key: 'workshop',  icon: '🛠️', label: 'Workshop · 45–60 min', description: 'A hands-on session where the audience builds or learns alongside you.' }
+        ],
+        offerTitle: 'What we offer speakers',
+        offer: [
+          'A friendly audience and homemade cake',
+          'Optional dry-run with an organizer beforehand',
+          'Slide review and topic brainstorming if you want',
+          'Pick your language: German, English, or either',
+          'Optional recording — only if you opt in'
+        ],
+        emailContentsTitle: 'What to include in your email',
+        emailContents: [
+          'Your name',
+          'Talk title',
+          'Short abstract (2–4 sentences)',
+          'Preferred format (Lightning / Standard / Workshop)',
+          'Language (DE / EN / either)',
+          'Optional one-sentence bio'
+        ],
+        selection: 'Rolling submissions — we usually reply within about two weeks.',
+        buttonSubmit: 'Submit a talk',
+        buttonLearnMore: 'Learn more',
+        backToMain: 'Back to main page',
+        mailtoSubject: 'Talk submission for HVLtech',
+        mailtoBody:
+          'Hi HVLtech organizers,\n\n' +
+          'I would like to submit a talk:\n\n' +
+          'Name:\n' +
+          'Talk title:\n' +
+          'Short abstract (2–4 sentences):\n' +
+          '\n' +
+          'Preferred format (Lightning / Standard / Workshop):\n' +
+          'Language (DE / EN / either):\n' +
+          'Short bio (optional, one sentence):\n\n' +
+          'Thanks!\n'
+      },
+      footerSpeakers: 'Speakers',
       kids: {
         // Hero
         title: 'KIDS LABS',

--- a/src/utils/buildMailto.ts
+++ b/src/utils/buildMailto.ts
@@ -1,0 +1,5 @@
+export function buildMailto(opts: { to: string; subject: string; body: string }): string {
+    const params = new URLSearchParams({ subject: opts.subject, body: opts.body });
+    const qs = params.toString().replace(/\+/g, '%20');
+    return `mailto:${opts.to}?${qs}`;
+}


### PR DESCRIPTION
## Summary
This PR adds a dedicated "Call for Speakers" page and integrates it into the homepage, enabling the HVLtech community to submit talk proposals. The implementation includes a full-page speaker submission flow with multilingual support (German and English) and a reusable teaser component on the homepage.

<img width="1241" height="899" alt="image" src="https://github.com/user-attachments/assets/a7a8ae7d-e6c6-4226-be89-c89b88cd96d0" />
<img width="1241" height="1289" alt="image" src="https://github.com/user-attachments/assets/05dfde76-661d-4387-8270-d40adee68e05" />
<img width="1241" height="1289" alt="image" src="https://github.com/user-attachments/assets/681ef0e0-3693-43bc-a23c-ab234cb5731d" />

## Key Changes

- **New SpeakersPage component** (`src/pages/SpeakersPage.tsx`): A comprehensive page featuring:
  - Hero section with call-to-action
  - Audience description
  - Three talk format options (Lightning, Standard, Workshop) with descriptions
  - List of speaker benefits
  - Email submission guidelines with a structured checklist
  - Navigation back to homepage
  - SEO metadata configuration

- **New CallForSpeakers teaser component** (`src/component/callForSpeakers.tsx`): A reusable homepage section that:
  - Displays a brief teaser about speaking opportunities
  - Provides quick access to submit talks or learn more
  - Maintains consistent styling with the rest of the site

- **Utility function** (`src/utils/buildMailto.ts`): Helper to construct mailto links with subject and body parameters, properly encoding special characters

- **Translation support**: Added comprehensive German and English translations for all speaker-related content, including:
  - Page headlines and descriptions
  - Format definitions and benefits
  - Email submission template with pre-filled structure
  - Footer link label

- **Integration updates**:
  - Added `/speakers` route to App.tsx
  - Integrated CallForSpeakers component into HomePage
  - Added "Speakers" link to footer navigation

## Implementation Details

- Uses i18n for full multilingual support with translation objects for formats, offers, and email contents
- Implements consistent visual styling with the existing design system (Press Start 2P font, color scheme, button styles)
- Includes SEO configuration via useSeo hook
- Auto-scrolls to top on page load
- Provides pre-filled email template to streamline speaker submissions
- Responsive design with Tailwind CSS breakpoints