### PR TITLE
Show venue + RSS/iCal feeds + Map/Calendar actions on event cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,13 @@ dist-ssr
 *.local
 .env
 
+# Generated at build time by scripts/generate-feeds.ts
+public/rss.xml
+public/events.ics
+
+# Prototyping artifacts (not deployed)
+mockups/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "npm run generate-feeds",
     "build": "vite build",
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
@@ -12,7 +13,8 @@
     "preview": "vite preview",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist",
-    "fetch-events": "tsx scripts/fetch-meetup-events.ts"
+    "fetch-events": "tsx scripts/fetch-meetup-events.ts",
+    "generate-feeds": "tsx scripts/generate-feeds.ts"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/scripts/fetch-meetup-events.ts
+++ b/scripts/fetch-meetup-events.ts
@@ -59,6 +59,15 @@ function cleanDescription(desc: string): string {
   return truncate(stripMarkdown(body), MAX_DESCRIPTION_LENGTH);
 }
 
+const DEFAULT_VENUE_BY_TITLE: Record<string, string> = {
+  'Programmiercafé': 'Kulturhaus „Johannes R. Becher" (Havelländer Weg 67, 14612 Falkensee)',
+};
+
+function resolveLocation(rawLocation: string, title: string): string {
+  if (rawLocation.trim().length > 0) return rawLocation;
+  return DEFAULT_VENUE_BY_TITLE[title] || '';
+}
+
 async function fetchEvents(): Promise<void> {
   console.log(`Fetching iCal feed from ${ICAL_URL}...`);
 
@@ -83,11 +92,12 @@ async function fetchEvents(): Promise<void> {
           ? String((rawUrl as { val: string }).val)
           : '';
 
+      const title = String(value.summary || '');
       events.push({
-        title: String(value.summary || ''),
+        title,
         dateTime: formatLocalISO(start),
         endTime: end && !isNaN(end.getTime()) ? formatLocalISO(end) : '',
-        location: String(value.location || ''),
+        location: resolveLocation(String(value.location || ''), title),
         description: cleanDescription(String(value.description || '')),
         eventUrl,
       });

--- a/scripts/generate-feeds.ts
+++ b/scripts/generate-feeds.ts
@@ -1,0 +1,163 @@
+import { writeFileSync, readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INPUT_PATH = resolve(__dirname, '../src/data/meetup-events.json');
+const RSS_OUTPUT = resolve(__dirname, '../public/rss.xml');
+const ICS_OUTPUT = resolve(__dirname, '../public/events.ics');
+
+const SITE_URL = 'https://hvltech.de';
+const SITE_TITLE = 'HVLtech — Havelland Tech Community';
+const SITE_DESCRIPTION = 'Upcoming meetups of the Havelland Tech Community in Falkensee.';
+const SITE_LANGUAGE = 'en-de';
+
+interface MeetupEvent {
+    title: string;
+    dateTime: string;
+    endTime: string;
+    location: string;
+    description: string;
+    eventUrl: string;
+}
+
+interface MeetupEventsData {
+    fetchedAt: string;
+    upcomingEvents: MeetupEvent[];
+}
+
+function pad(n: number): string {
+    return String(n).padStart(2, '0');
+}
+
+function toIcsStamp(date: Date): string {
+    return `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}T${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}Z`;
+}
+
+function toLocalIcsStamp(date: Date): string {
+    return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}T${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
+}
+
+function escapeIcs(text: string): string {
+    return text
+        .replace(/\\/g, '\\\\')
+        .replace(/\n/g, '\\n')
+        .replace(/,/g, '\\,')
+        .replace(/;/g, '\\;');
+}
+
+function escapeXml(text: string): string {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
+}
+
+function eventId(event: MeetupEvent): string {
+    const idMatch = event.eventUrl.match(/\/events\/([^/?]+)/);
+    if (idMatch) return idMatch[1];
+    const slug = (event.title + '-' + event.dateTime).replace(/[^A-Za-z0-9]+/g, '-').toLowerCase();
+    return slug.replace(/^-+|-+$/g, '');
+}
+
+function eventGuid(event: MeetupEvent): string {
+    return `hvltech-evt-${eventId(event)}`;
+}
+
+function foldIcsLine(line: string): string {
+    if (line.length <= 75) return line;
+    const out: string[] = [];
+    let remaining = line;
+    out.push(remaining.slice(0, 75));
+    remaining = remaining.slice(75);
+    while (remaining.length > 0) {
+        out.push(' ' + remaining.slice(0, 74));
+        remaining = remaining.slice(74);
+    }
+    return out.join('\r\n');
+}
+
+function buildIcs(events: MeetupEvent[]): string {
+    const lines: string[] = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//HVLtech//Events//EN',
+        'CALSCALE:GREGORIAN',
+        'METHOD:PUBLISH',
+        `X-WR-CALNAME:${escapeIcs(SITE_TITLE)}`,
+        'X-WR-TIMEZONE:Europe/Berlin',
+    ];
+
+    const nowStamp = toIcsStamp(new Date());
+
+    for (const event of events) {
+        const start = new Date(event.dateTime);
+        if (isNaN(start.getTime())) continue;
+        const end = event.endTime ? new Date(event.endTime) : new Date(start.getTime() + 2 * 60 * 60 * 1000);
+        const uid = `${eventGuid(event)}@hvltech.de`;
+        lines.push('BEGIN:VEVENT');
+        lines.push(foldIcsLine(`UID:${uid}`));
+        lines.push(`DTSTAMP:${nowStamp}`);
+        lines.push(`DTSTART;TZID=Europe/Berlin:${toLocalIcsStamp(start)}`);
+        lines.push(`DTEND;TZID=Europe/Berlin:${toLocalIcsStamp(end)}`);
+        lines.push(foldIcsLine(`SUMMARY:${escapeIcs(event.title)}`));
+        if (event.location) lines.push(foldIcsLine(`LOCATION:${escapeIcs(event.location)}`));
+        if (event.description) lines.push(foldIcsLine(`DESCRIPTION:${escapeIcs(event.description)}`));
+        if (event.eventUrl) lines.push(foldIcsLine(`URL:${event.eventUrl}`));
+        lines.push('END:VEVENT');
+    }
+
+    lines.push('END:VCALENDAR');
+    return lines.join('\r\n') + '\r\n';
+}
+
+function buildRss(events: MeetupEvent[], generatedAt: Date): string {
+    const items = events.map((event) => {
+        const start = new Date(event.dateTime);
+        if (isNaN(start.getTime())) return '';
+        const guid = eventGuid(event);
+        const pubDate = start.toUTCString();
+        const link = event.eventUrl || `${SITE_URL}/`;
+        const descParts: string[] = [];
+        if (event.location) descParts.push(`📍 ${event.location}`);
+        if (event.description) descParts.push(event.description);
+        const description = descParts.join('\n\n');
+        return `    <item>
+      <title>${escapeXml(event.title)}</title>
+      <link>${escapeXml(link)}</link>
+      <guid isPermaLink="false">${escapeXml(guid)}</guid>
+      <pubDate>${pubDate}</pubDate>
+      <description>${escapeXml(description)}</description>
+    </item>`;
+    }).filter(Boolean).join('\n');
+
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(SITE_TITLE)}</title>
+    <link>${SITE_URL}</link>
+    <description>${escapeXml(SITE_DESCRIPTION)}</description>
+    <language>${SITE_LANGUAGE}</language>
+    <lastBuildDate>${generatedAt.toUTCString()}</lastBuildDate>
+    <atom:link href="${SITE_URL}/rss.xml" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>
+`;
+}
+
+function main(): void {
+    const raw = readFileSync(INPUT_PATH, 'utf-8');
+    const data: MeetupEventsData = JSON.parse(raw);
+    const events = data.upcomingEvents
+        .slice()
+        .sort((a, b) => new Date(a.dateTime).getTime() - new Date(b.dateTime).getTime());
+
+    writeFileSync(RSS_OUTPUT, buildRss(events, new Date()));
+    writeFileSync(ICS_OUTPUT, buildIcs(events));
+    console.log(`Wrote ${events.length} events to ${RSS_OUTPUT} and ${ICS_OUTPUT}`);
+}
+
+main();

--- a/src/component/event.tsx
+++ b/src/component/event.tsx
@@ -7,13 +7,16 @@ import meetupData from "../data/meetup-events.json";
 type CardProps = {
     datum: string;
     header: string;
-    place: string;
+    timeStr: string;
+    venueName: string;
     address: string;
     contain: string;
     link?: string;
     internalLink?: string;
     isLast?: boolean;
     showProgram?: boolean;
+    mapUrl?: string;
+    calendarUrl?: string;
 };
 
 interface MeetupEvent {
@@ -23,6 +26,48 @@ interface MeetupEvent {
     location: string;
     description: string;
     eventUrl: string;
+}
+
+const DEFAULT_VENUE_BY_TITLE: Record<string, string> = {
+    'Programmiercafé': 'Kulturhaus „Johannes R. Becher" (Havelländer Weg 67, 14612 Falkensee)',
+};
+
+function parseLocation(raw: string, title: string): { venueName: string; address: string } {
+    const value = raw.trim().length > 0 ? raw : (DEFAULT_VENUE_BY_TITLE[title] || '');
+    const match = value.match(/^([^(]+)\(([^)]+)\)/);
+    if (match) return { venueName: match[1].trim(), address: match[2].trim() };
+    return { venueName: value, address: '' };
+}
+
+function buildMapUrl(venueName: string, address: string): string | undefined {
+    const query = address || venueName;
+    if (!query) return undefined;
+    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
+}
+
+function pad(n: number): string {
+    return String(n).padStart(2, '0');
+}
+
+function toCalendarStamp(date: Date): string {
+    return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}T${pad(date.getHours())}${pad(date.getMinutes())}00`;
+}
+
+function buildCalendarUrl(event: MeetupEvent, venueName: string, address: string): string | undefined {
+    const start = new Date(event.dateTime);
+    if (isNaN(start.getTime())) return undefined;
+    const end = event.endTime ? new Date(event.endTime) : new Date(start.getTime() + 2 * 60 * 60 * 1000);
+    const dates = `${toCalendarStamp(start)}/${toCalendarStamp(end)}`;
+    const locationStr = [venueName, address].filter(Boolean).join(', ');
+    const params = new URLSearchParams({
+        action: 'TEMPLATE',
+        text: event.title,
+        dates,
+        location: locationStr,
+        details: event.description + (event.eventUrl ? `\n\n${event.eventUrl}` : ''),
+        ctz: 'Europe/Berlin',
+    });
+    return `https://calendar.google.com/calendar/render?${params.toString()}`;
 }
 
 function useEventCards(events: MeetupEvent[]): CardProps[] {
@@ -41,9 +86,7 @@ function useEventCards(events: MeetupEvent[]): CardProps[] {
             ? `${day}\n${month}`
             : `${month}\n${day}`;
 
-        const locationParts = event.location.match(/^([^(]+)\(([^)]+)\)/);
-        const venueName = locationParts ? locationParts[1].trim() : event.location;
-        const address = locationParts ? locationParts[2].trim() : '';
+        const { venueName, address } = parseLocation(event.location, event.title);
 
         let timeStr: string;
         if (end && end.getTime() !== start.getTime()) {
@@ -56,18 +99,19 @@ function useEventCards(events: MeetupEvent[]): CardProps[] {
             timeStr = `${t('event.at')} ${timeFormatted}${oclock ? ' ' + oclock : ''}`;
         }
 
-        const place = venueName ? `${venueName} ${timeStr}` : timeStr;
-
         const isKidsLabs = /kids\s*labs/i.test(event.title);
 
         return {
             datum,
             header: event.title,
-            place,
+            timeStr,
+            venueName,
             address,
             contain: event.description,
             link: isKidsLabs ? undefined : (event.eventUrl || undefined),
             internalLink: isKidsLabs ? '/labs' : undefined,
+            mapUrl: buildMapUrl(venueName, address),
+            calendarUrl: buildCalendarUrl(event, venueName, address),
         };
     });
 }
@@ -85,14 +129,52 @@ function formatTime(date: Date, lang: string): string {
     return minutes === 0 ? `${h12}${period}` : `${h12}:${String(minutes).padStart(2, '0')}${period}`;
 }
 
-const Card = ({ datum, header, place, address, contain, link, internalLink, showProgram }: CardProps) => {
+const PinIcon = ({ size = 16, color = "#15803d" }: { size?: number; color?: string }) => (
+    <svg width={size} height={size} viewBox="0 0 16 16" shapeRendering="crispEdges" className="flex-shrink-0">
+        <rect x="6" y="1" width="4" height="2" fill={color} />
+        <rect x="4" y="3" width="8" height="6" fill={color} />
+        <rect x="6" y="5" width="4" height="2" fill="#fff" />
+        <rect x="7" y="9" width="2" height="4" fill={color} />
+    </svg>
+);
+
+const RssIcon = ({ size = 12, color = "#0d1b21" }: { size?: number; color?: string }) => (
+    <svg width={size} height={size} viewBox="0 0 14 14" shapeRendering="crispEdges">
+        <rect x="1" y="9" width="3" height="3" fill={color} />
+        <rect x="1" y="5" width="3" height="3" fill={color} /><rect x="5" y="9" width="3" height="3" fill={color} />
+        <rect x="1" y="1" width="3" height="3" fill={color} /><rect x="5" y="5" width="3" height="3" fill={color} /><rect x="9" y="9" width="3" height="3" fill={color} />
+    </svg>
+);
+
+const FeedGroup = () => (
+    <div className="inline-flex border-[3px] border-black shadow-[3px_3px_0_#000]">
+        <a
+            href="/rss.xml"
+            className="inline-flex items-center gap-1.5 px-3 py-2 no-underline font-['Press_Start_2P'] text-[8px] text-[#0d1b21] bg-amber-400 border-r-[3px] border-black hover:bg-green-700 hover:text-white active:translate-x-px active:translate-y-px"
+        >
+            <RssIcon />
+            RSS
+        </a>
+        <a
+            href="/events.ics"
+            className="inline-flex items-center gap-1.5 px-3 py-2 no-underline font-['Press_Start_2P'] text-[8px] text-[#0d1b21] bg-white hover:bg-green-700 hover:text-white active:translate-x-px active:translate-y-px"
+        >
+            📅 iCAL
+        </a>
+    </div>
+);
+
+const actionBtn = "inline-flex items-center gap-1.5 no-underline bg-white text-[#0d1b21] border-[3px] border-black shadow-[3px_3px_0_#000] px-2.5 py-1.5 font-['Press_Start_2P'] text-[8px] hover:bg-amber-100 active:translate-x-px active:translate-y-px";
+
+const Card = ({ datum, header, timeStr, venueName, address, contain, link, internalLink, showProgram, mapUrl, calendarUrl }: CardProps) => {
+    const { t } = useTranslation();
     const isCafe = header.toLowerCase().includes('programmiercaf');
-    const hasLink = Boolean(link || internalLink);
-    const cardContent = (
+    const venueShortAddress = address.split(',')[0].trim();
+    const hasActions = Boolean(venueName || mapUrl || calendarUrl);
+
+    return (
         <div className="border-4 border-black shadow-[4px_4px_0px_#000] p-2 md:p-4 w-full flex flex-col items-center justify-center">
-            <div
-                key={`contentCard-${datum}`}
-                className={` w-full flex md:flex-row flex-col items-center justify-between md:gap-6 gap-3 max-w-[1120px] bg-white ${hasLink ? 'hover:shadow-[6px_6px_0px_#000] cursor-pointer hover:bg-green-50' : ''}`}>
+            <div className="w-full flex md:flex-row flex-col items-center md:items-start justify-between md:gap-6 gap-3 max-w-[1120px] bg-white">
                 <BorderedBox>
                     <div
                         className={`
@@ -105,34 +187,48 @@ const Card = ({ datum, header, place, address, contain, link, internalLink, show
                         {datum}
                     </div>
                 </BorderedBox>
-                <div className='flex md:items-start items-center flex-col w-full px-10'>
-                    <h3 className={`md:text-xl ${isCafe ? "text-cyan-700" : "text-green-700"} font-['Press_Start_2P'] self-center md:self-auto`}>{header}</h3>
-                    <p className="font-bold py-2 ">{place}</p>
-                    <p className='text-sm text-pretty py-2'> {address}</p>
-                    <p className="italic">{contain}</p>
+                <div className='flex md:items-start items-center flex-col w-full px-4 md:px-6 gap-2'>
+                    {internalLink ? (
+                        <Link to={internalLink} className={`md:text-xl ${isCafe ? "text-cyan-700" : "text-green-700"} font-['Press_Start_2P'] self-center md:self-auto no-underline hover:underline`}>
+                            <h3 className="m-0">{header}</h3>
+                        </Link>
+                    ) : link ? (
+                        <a href={link} target="_blank" rel="noopener noreferrer" className={`md:text-xl ${isCafe ? "text-cyan-700" : "text-green-700"} font-['Press_Start_2P'] self-center md:self-auto no-underline hover:underline`}>
+                            <h3 className="m-0">{header}</h3>
+                        </a>
+                    ) : (
+                        <h3 className={`md:text-xl ${isCafe ? "text-cyan-700" : "text-green-700"} font-['Press_Start_2P'] self-center md:self-auto m-0`}>{header}</h3>
+                    )}
+                    <p className="font-bold">{timeStr}</p>
+                    {contain && <p className="italic text-gray-700 whitespace-pre-line">{contain}</p>}
+                    {hasActions && (
+                        <div className="flex flex-wrap items-center gap-2 md:gap-3 mt-1 w-full md:justify-start justify-center">
+                            {venueName && (
+                                <span className="inline-flex items-center gap-2 bg-amber-100 text-[#0d1b21] border-[3px] border-black shadow-[3px_3px_0_#000] px-2.5 py-1.5 text-[13px] leading-tight">
+                                    <PinIcon size={16} color="#92400e" />
+                                    <span>
+                                        <strong className="text-[#00274a] font-bold">{venueName}</strong>
+                                        {venueShortAddress && <span> · {venueShortAddress}</span>}
+                                    </span>
+                                </span>
+                            )}
+                            {mapUrl && (
+                                <a href={mapUrl} target="_blank" rel="noopener noreferrer" className={actionBtn}>
+                                    🗺 {t('event.actions.map')}
+                                </a>
+                            )}
+                            {calendarUrl && (
+                                <a href={calendarUrl} target="_blank" rel="noopener noreferrer" className={actionBtn}>
+                                    📥 {t('event.actions.calendar')}
+                                </a>
+                            )}
+                        </div>
+                    )}
                 </div>
             </div>
             {showProgram && <Program />}
         </div>
     );
-
-    if (internalLink) {
-        return (
-            <Link to={internalLink} className="w-full flex justify-center no-underline text-inherit">
-                {cardContent}
-            </Link>
-        );
-    }
-
-    if (link) {
-        return (
-            <a href={link} target="_blank" rel="noopener noreferrer" className="w-full flex justify-center no-underline text-inherit">
-                {cardContent}
-            </a>
-        );
-    }
-
-    return cardContent;
 }
 
 const Event = () => {
@@ -142,7 +238,10 @@ const Event = () => {
     return (
         <div
             className="bg-white gap-2.5 w-full px-2 md:px-8 py-4 md:py-8 flex flex-col items-center justify-around max-w-[1120px] mx-auto">
-            <h2 className="font-['Press_Start_2P'] font-normal text-base text-[#00274a]">{t('event.nextEvent')}</h2>
+            <div className="flex flex-wrap items-center justify-center gap-3 md:gap-4 mb-2">
+                <h2 className="font-['Press_Start_2P'] font-normal text-base text-[#00274a] m-0">{t('event.nextEvent')}</h2>
+                <FeedGroup />
+            </div>
             {cardData.map((event: CardProps, index: number) => (
                 <Card key={index} {...event} />
             ))}

--- a/src/data/meetup-events.json
+++ b/src/data/meetup-events.json
@@ -5,7 +5,7 @@
       "title": "Programmiercafé",
       "dateTime": "2026-04-05T11:00:00",
       "endTime": "2026-04-05T13:00:00",
-      "location": "",
+      "location": "Kulturhaus „Johannes R. Becher\" (Havelländer Weg 67, 14612 Falkensee)",
       "description": "A space for working on projects & learning new stuff together. 💻☕️\nPlease RSVP if you intend to join, as we have limited space. 😊",
       "eventUrl": "https://www.meetup.com/havelland-technology-falkensee/events/313148614/"
     },
@@ -13,7 +13,7 @@
       "title": "Programmiercafé",
       "dateTime": "2026-02-27T11:00:00",
       "endTime": "2026-02-27T13:00:00",
-      "location": "",
+      "location": "Kulturhaus „Johannes R. Becher\" (Havelländer Weg 67, 14612 Falkensee)",
       "description": "A space for working on projects & learning new stuff together. 💻☕️\nPlease RSVP if you intend to join, as we have limited space. 😊",
       "eventUrl": "https://www.meetup.com/havelland-technology-falkensee/events/313148614/"
     },
@@ -21,7 +21,7 @@
       "title": "Programmiercafé",
       "dateTime": "2026-03-13T11:00:00",
       "endTime": "2026-03-13T13:00:00",
-      "location": "",
+      "location": "Kulturhaus „Johannes R. Becher\" (Havelländer Weg 67, 14612 Falkensee)",
       "description": "A space for working on projects & learning new stuff together. 💻☕️\nPlease RSVP if you intend to join, as we have limited space. 😊",
       "eventUrl": "https://www.meetup.com/havelland-technology-falkensee/events/313172260/"
     },
@@ -29,7 +29,7 @@
       "title": "Programmiercafé",
       "dateTime": "2026-03-27T11:00:00",
       "endTime": "2026-03-27T13:00:00",
-      "location": "",
+      "location": "Kulturhaus „Johannes R. Becher\" (Havelländer Weg 67, 14612 Falkensee)",
       "description": "A space for working on projects & learning new stuff together. 💻☕️\nPlease RSVP if you intend to join, as we have limited space. 😊",
       "eventUrl": "https://www.meetup.com/havelland-technology-falkensee/events/ltgcvtyjcfbkc/"
     }

--- a/src/translate/de.ts
+++ b/src/translate/de.ts
@@ -85,6 +85,10 @@ const de = {
       oclock: 'Uhr',
       fromTo: 'von {{from}} bis {{to}}',
       nextEvent: 'Nächstes Event',
+      actions: {
+        map: 'KARTE',
+        calendar: 'KALENDER',
+      },
     },
       gallery: {
         highline: 'Galerie'},

--- a/src/translate/en.ts
+++ b/src/translate/en.ts
@@ -86,6 +86,10 @@ const en = {
       oclock: '',
       fromTo: 'from {{from}} to {{to}}',
       nextEvent: 'Next Event',
+      actions: {
+        map: 'MAP',
+        calendar: 'CALENDAR',
+      },
     },
       gallery:
           {highline: 'Gallery'},


### PR DESCRIPTION
## Summary
- Event cards now surface the venue as a pixel-styled amber tag next to **MAP** and **CALENDAR** action buttons, all on a single row below the description. Title links through to the Meetup event.
- Added RSS + iCAL pill group next to the *Next Event* heading.
- Build-time generator (`scripts/generate-feeds.ts`, wired via `prebuild`) writes `public/rss.xml` (stable `hvltech-evt-<meetupId>` GUIDs so readers don't double-fire) and `public/events.ics` (Europe/Berlin VCALENDAR with matching UIDs). Both regenerate on every deploy and are gitignored.
- `DEFAULT_VENUE_BY_TITLE` map in `scripts/fetch-meetup-events.ts` fills empty Meetup locations for known recurring events (Programmiercafé → Kulturhaus). Same fallback lives in `event.tsx` so the UI is robust even with stale data.

## Test plan
- [ ] `npm run dev` and confirm event cards render with the amber venue tag + MAP + CALENDAR buttons on a single row
- [ ] Click the event title → opens Meetup event in new tab
- [ ] Click **MAP** → opens Google Maps for the address
- [ ] Click **CALENDAR** → opens Google Calendar add-event with title / start / end / location / description / Europe/Berlin TZ pre-filled
- [ ] Click **RSS** in the heading group → serves `/rss.xml`; verify GUIDs (`hvltech-evt-<id>`) are stable per event
- [ ] Click **iCAL** → serves `/events.ics`; import into Apple Calendar / Google Calendar and verify events show up at the correct local times
- [ ] Toggle DE/EN — both `KARTE`/`KALENDER` and `MAP`/`CALENDAR` labels render correctly
- [ ] `npm run build` succeeds and the generated `dist/rss.xml` + `dist/events.ics` are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)